### PR TITLE
chore: update repo ownership to match current org [SRE-314]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,13 +1,12 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  # Name of the project 
+  # Name of the project
   name: GitHub-Jira-Integration
   description: automatically create or bind pull request to jira issue, resolve it when merged
   # Specifies the directory of the docs
   annotations:
     backstage.io/techdocs-ref: dir:.
-
 # The spec defines who becomes the owner of the system in backstage
 spec:
   type: github action
@@ -16,4 +15,4 @@ spec:
   # Name of the squad responsible for the project, e.g. sre or cpi
   owner: fs-payments
   # Name of the greater system, e.g. "solar" is a part of the home system
-  system: Financial
+  system: financial-services-division


### PR DESCRIPTION
### Changes

Set squad owner and division in *catalog-info.yaml* to match new org structure

### Motivation

Make sure code repository ownership reflect the current organization

#### See also
- [Code ownership notion page](https://www.notion.so/montaapp/Code-ownership-58ade3fceb1e4cb89138a7fc10c5a07f)
- [Repo ownership review spreadsheet](https://docs.google.com/spreadsheets/d/1LtA1kfE7YSUBEFAbP02XnmSZp5X_eBPmea6x832VFP4/edit?gid=0#gid=0)
- [Ticket - SRE-314](https://montaapp.atlassian.net/browse/SRE-314)